### PR TITLE
Added manifest parser, bom creation, and CLI utility.

### DIFF
--- a/Nerves/cyclonedx/README.md
+++ b/Nerves/cyclonedx/README.md
@@ -1,0 +1,47 @@
+# CycloneDX Nerves Manifest Prototype
+This project creates CycloneDX Software Bill-of-Materials (SBOM) from Nerves manifests.
+
+## Requirements
+Node.js v8.0.0 or higher
+
+## Usage
+
+#### Installing
+The following command will install the `cyclonedx-nerves` tool globally so that it can be called outside of the current
+project.
+
+```bash
+npm install -g
+```
+
+#### Getting Help
+```bash
+$ cyclonedx-nerves -h
+Usage: cyclonedx-nerves [OPTIONS]
+
+Creates CycloneDX Software Bill-of-Materials (SBOM) from Nerves buildroot manifests
+
+Options:
+  -v, --version               output the version number
+  -m, --manifest <manifest>   Nerves manifest from which to create a BOM from (default: "buildroot.show-info.json")
+  -o, --output <output>       Write BOM to file (default: "bom.json")
+  -h, --help                  display help for command
+```
+
+#### Example (default: JSON)
+```bash
+cyclonedx-nerves
+```
+
+#### Example (XML)
+```bash
+cyclonedx-nerves -o bom.xml -m buildroot.show-info.json
+```
+
+#### Example (JSON)
+```bash
+cyclonedx-nerves -o bom.json -m buildroot.show-info.json
+```
+
+## License
+Permission to modify and redistribute is granted under the terms of the MIT license.

--- a/Nerves/cyclonedx/bin/cyclonedx-nerves
+++ b/Nerves/cyclonedx/bin/cyclonedx-nerves
@@ -1,0 +1,51 @@
+#!/usr/bin/env node
+/*
+* MIT License
+*
+* Permission is hereby granted, free of charge, to any person obtaining a copy
+* of this software and associated documentation files (the "Software"), to deal
+* in the Software without restriction, including without limitation the rights
+* to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+* copies of the Software, and to permit persons to whom the Software is
+* furnished to do so, subject to the following conditions:
+*
+* The above copyright notice and this permission notice shall be included in all
+* copies or substantial portions of the Software.
+*
+* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+* IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+* OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+* SOFTWARE.
+*
+* SPDX-License-Identifier: MIT
+*/
+const commander = require('commander');
+const program = require('../package.json');
+const bomHelper = require("../index.js");
+const fs = require("fs");
+
+commander
+  .description(program.description)
+  .version(program.version, '-v, --version')
+  .usage('[OPTIONS]')
+  .option('-m, --manifest <manifest>', "Nerves manifest from which to create a BOM from", "buildroot.show-info.json")
+  .option('-o, --output <output>', "Write BOM to file", "bom.json")
+  .parse(process.argv);
+
+let manifest = commander.manifest;
+let output = commander.output;
+
+if (!fs.existsSync(manifest)) {
+  console.log("Cannot find manifest file");
+  process.exit(1);
+}
+
+if (!output.endsWith("xml") && !output.endsWith("json")) {
+  console.log("Unsupported file extension. Output filename must end with .xml or .json");
+  process.exit(1);
+}
+
+bomHelper.createbom(manifest, output);

--- a/Nerves/cyclonedx/index.js
+++ b/Nerves/cyclonedx/index.js
@@ -1,0 +1,109 @@
+/*
+* MIT License
+*
+* Permission is hereby granted, free of charge, to any person obtaining a copy
+* of this software and associated documentation files (the "Software"), to deal
+* in the Software without restriction, including without limitation the rights
+* to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+* copies of the Software, and to permit persons to whom the Software is
+* furnished to do so, subject to the following conditions:
+*
+* The above copyright notice and this permission notice shall be included in all
+* copies or substantial portions of the Software.
+*
+* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+* IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+* OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+* SOFTWARE.
+*
+* SPDX-License-Identifier: MIT
+*/
+const Bom = require('@cyclonedx/bom/model/Bom');
+const Component = require('@cyclonedx/bom/model/Component');
+const License = require('@cyclonedx/bom/model/License');
+const LicenseChoice = require('@cyclonedx/bom/model/LicenseChoice');
+const ExternalReference = require('@cyclonedx/bom/model/ExternalReference');
+const ExternalReferenceList = require('@cyclonedx/bom/model/ExternalReferenceList');
+const Swid = require('@cyclonedx/bom/model/Swid');
+const { PackageURL } = require('packageurl-js');
+const fs = require("fs");
+
+
+/**
+ * Creates a BOM from the specified manifest and writes it to the specified output file.
+ */
+exports.createbom = function createbom(manifest, output) {
+  let bom = new Bom();
+  // TODO: add BOM metadata object in the future. As of now, this object is not yet implemented in CycloneDX Node Module
+  // See: https://cyclonedx.org/use-cases/#packaging-and-distribution
+  parseManifest(bom, manifest);
+  writeBom(bom, output);
+};
+
+/**
+ * Parses the manifest, creates components, and adds them to the specified BOM.
+ */
+function parseManifest(bom, manifest) {
+  let buildroot = JSON.parse(fs.readFileSync(manifest, 'utf8'));
+  for (let key in buildroot) {
+    let lib = buildroot[key];
+    if (lib.virtual === true) {
+      continue; // Do not include virtual packages
+    }
+    // Create a new CycloneDX component and populate identity information
+    let component = new Component();
+    component.type = "library"; // Must be a valid CycloneDX component type
+    component.name = key;
+    component.version = (lib.version) ? lib.version : "unknown"; // Version is required. Not all packages have one.
+
+    // Set the component PackageURL, CPE, and SWID
+    // See: https://cyclonedx.org/use-cases/#known-vulnerabilities
+    component.purl = new PackageURL("hex", null, component.name, component.version, null, null).toString();
+    component.cpe = "cpe:2.3:o:linux:linux_kernel:2.6.30.1:*:*:*:*:*:*:*"; // TODO: Possible to determine?
+    component.swid = new Swid("tagId-goes-here", component.name, component.version); // TODO: Possible to determine?
+
+    // TODO: Possible future work - Download packages and calculate hash values of each package. Add them to BOM.
+    // See: https://cyclonedx.org/use-cases/#integrity-verification
+
+    // Process licenses and add the unresolved license name to CycloneDX
+    // See: https://cyclonedx.org/use-cases/#license-compliance
+    if (lib.licenses) {
+      let license = new License();
+      license.name = lib.licenses;
+      let licenseChoice = new LicenseChoice();
+      licenseChoice.licenses = [license];
+      component.licenses = licenseChoice;
+    }
+
+    // Process downloads and create CycloneDX external references
+    let externalReferenceList = new ExternalReferenceList();
+    if (lib.downloads) {
+      for (let index in lib.downloads) {
+        let download =  lib.downloads[index];
+        if (download.uris) {
+          let reference = new ExternalReference("distribution", download.uris[0]
+            .replace("ftp+ftp", "ftp").replace("http+http", "http").replace("https+https", "https"));
+          externalReferenceList.externalReferences.push(reference);
+        }
+      }
+    }
+    component.externalReferences = externalReferenceList;
+
+    // Add the component to the BOM.
+    bom.addComponent(component);
+  }
+}
+
+/**
+ * Writes the BOM to the specified output file.
+ */
+function writeBom(bom, output) {
+  if (output.endsWith(".xml")) {
+    fs.writeFile(output, bom.toXML(), () => {});
+  } else if (output.endsWith(".json")) {
+    fs.writeFile(output, bom.toJSON(), () => {});
+  }
+}

--- a/Nerves/cyclonedx/package.json
+++ b/Nerves/cyclonedx/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "cyclonedx-nerves-prototype",
+  "version": "1.0.0",
+  "description": "Creates CycloneDX Software Bill-of-Materials (SBOM) from Nerves buildroot manifests",
+  "license": "MIT",
+  "main": "index.js",
+  "bin": {
+    "cyclonedx-nerves": "./bin/cyclonedx-nerves"
+  },
+  "engines": {
+    "node": ">=8.0.0"
+  },
+  "dependencies": {
+    "@cyclonedx/bom": "github:CycloneDX/cyclonedx-node-module#master",
+    "commander": "^5.1.0",
+    "packageurl-js": "^0.0.2"
+  },
+  "files": [
+    "index.js",
+    "bin/"
+  ]
+}


### PR DESCRIPTION
This PR adds a simple command line utility which takes in a buildroot manifest, parses it, and outputs a valid CycloneDX SBOM (either JSON or XML).

The CLI only functionality is isolated in the bin/cyclonedx-nerves file whereas the actual parsing and bom creation work is performed in the main index.js file. That file is commented to provide details about what is going on. This utility can also likely be used for similar parsing/conversion projects in the future with minimal changes.

Note: This utility relies on an unreleased version of CycloneDX Node Module. As of now, the current production release is v1.1.3 however, this utility is leveraging unreleased v2.0.0-SNAPSHOT code directly from the projects master branch. Once 2.0.0 is released, package.json should be updated to pin to that version rather than the GitHub URL it currently points to.

Attached are XML and JSON boms produced by this tool.
[boms.zip](https://github.com/sparrell/SBoM-by-example/files/4800242/boms.zip)

